### PR TITLE
Update ReadME / avoid chances for same attribute names in hijack / add h*w assertion

### DIFF
--- a/hyper_tile/hyper_tile.py
+++ b/hyper_tile/hyper_tile.py
@@ -113,12 +113,14 @@ def split_attention(
             else:
                 hw = x.size(1)
                 h, w = round(math.sqrt(hw * aspect_ratio)), round(math.sqrt(hw / aspect_ratio))
+                # h*w should be equal to hw
+                assert h * w == hw, f"Invalid aspect ratio {aspect_ratio} for input of shape {x.shape}"
 
                 factor = 2**depth if scale_depth else 1
                 nh = random_divisor(h, latent_tile_size * factor, swap_size)
                 nw = random_divisor(w, latent_tile_size * factor, swap_size)
 
-                module._split_sizes.append((nh, nw))  # type: ignore
+                module._split_sizes_hypertile.append((nh, nw))  # type: ignore
 
                 if nh * nw > 1:
                     x = rearrange(x, "b (nh h nw w) c -> (b nh nw) (h w) c", h=h // nh, w=w // nw, nh=nh, nw=nw)
@@ -141,18 +143,18 @@ def split_attention(
                     logging.info(f"HyperTile hijacking attention layer at depth {depth}: {layer_name}")
 
                     # save original forward for recovery later
-                    setattr(module, "_original_forward", module.forward)
+                    setattr(module, "_original_forward_hypertile", module.forward)
                     setattr(module, "forward", self_attn_forward(module.forward, depth, layer_name, module))
 
-                    setattr(module, "_split_sizes", [])
+                    setattr(module, "_split_sizes_hypertile", [])
         yield
     finally:
         for layer_name, module in layer.named_modules():
             # remove hijack
-            if hasattr(module, "_original_forward"):
-                if module._split_sizes:
-                    logging.debug(f"layer {layer_name} splitted with ({module._split_sizes})")
+            if hasattr(module, "_original_forward_hypertile"):
+                if module._split_sizes_hypertile:
+                    logging.debug(f"layer {layer_name} splitted with ({module._split_sizes_hypertile})")
 
-                setattr(module, "forward", module._original_forward)
-                del module._original_forward
-                del module._split_sizes
+                setattr(module, "forward", module._original_forward_hypertile)
+                del module._original_forward_hypertile
+                del module._split_sizes_hypertile

--- a/hyper_tile/hyper_tile.py
+++ b/hyper_tile/hyper_tile.py
@@ -10,7 +10,7 @@ import math
 import torch.nn as nn
 from einops import rearrange
 
-from .utils import random_divisor
+from .utils import random_divisor, find_hw_candidates
 
 
 # TODO add SD-XL layers
@@ -112,7 +112,7 @@ def split_attention(
             # U-Net
             else:
                 hw = x.size(1)
-                h, w = round(math.sqrt(hw * aspect_ratio)), round(math.sqrt(hw / aspect_ratio))
+                h, w = find_hw_candidates(hw, aspect_ratio)
                 # h*w should be equal to hw
                 assert h * w == hw, f"Invalid aspect ratio {aspect_ratio} for input of shape {x.shape}"
 

--- a/hyper_tile/utils.py
+++ b/hyper_tile/utils.py
@@ -3,7 +3,13 @@ from __future__ import annotations
 import gc
 import torch
 import random
+import math
+from functools import cache
 
+RNG_INSTANCE = random.Random()
+
+def set_seed(seed: int) -> None:
+    RNG_INSTANCE.seed(seed)
 
 def flush() -> None:
     gc.collect()
@@ -20,6 +26,39 @@ def random_divisor(value: int, min_value: int, /, max_options: int = 1) -> int:
 
     ns = [value // i for i in divisors[:max_options]]  # has at least 1 element
 
-    idx = random.randint(0, len(ns) - 1)
+    idx = RNG_INSTANCE.randint(0, len(ns) - 1)
 
     return ns[idx]
+
+def iterative_closest_divisors(hw:int, aspect_ratio:float) -> tuple[int, int]:
+    """
+    Finds h and w such that h*w = hw and h/w = aspect_ratio
+    We check all possible divisors of hw and return the closest to the aspect ratio
+    """
+    divisors = [i for i in range(2, hw + 1) if hw % i == 0] # all divisors of hw
+    pairs = [(i, hw // i) for i in divisors] # all pairs of divisors of hw
+    ratios = [w/h for h, w in pairs] # all ratios of pairs of divisors of hw
+    closest_ratio = min(ratios, key=lambda x: abs(x - aspect_ratio)) # closest ratio to aspect_ratio
+    closest_pair = pairs[ratios.index(closest_ratio)] # closest pair of divisors to aspect_ratio
+    return closest_pair
+
+@cache
+def find_hw_candidates(hw:int, aspect_ratio:float) -> tuple[int, int]:
+    """
+    Finds h and w such that h*w = hw and h/w = aspect_ratio
+    """
+    h, w = round(math.sqrt(hw * aspect_ratio)), round(math.sqrt(hw / aspect_ratio))
+    # find h and w such that h*w = hw and h/w = aspect_ratio
+    if h * w != hw:
+        w_candidate = hw / h
+        # check if w is an integer
+        if not w_candidate.is_integer():
+            h_candidate = hw / w
+            # check if h is an integer
+            if not h_candidate.is_integer():
+                return iterative_closest_divisors(hw, aspect_ratio)
+            else:
+                h = int(h_candidate)
+        else:
+            w = int(w_candidate)
+    return h, w


### PR DESCRIPTION
The cursed nature of hijack contains chances to make duplicate attribute names, especially ControlNet.

Some code snippets are changed for future references.